### PR TITLE
Update firebase messaging implementation on Android

### DIFF
--- a/android/app/src/main/kotlin/io/simpledesign/sublin/Application.kt
+++ b/android/app/src/main/kotlin/io/simpledesign/sublin/Application.kt
@@ -1,18 +1,10 @@
 package io.simpledesign.sublin
 
 import io.flutter.app.FlutterApplication
-import io.flutter.plugin.common.PluginRegistry
-import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback
-import io.flutter.plugins.firebasemessaging.FlutterFirebaseMessagingService
 
-class Application : FlutterApplication(), PluginRegistrantCallback {
+class Application : FlutterApplication() {
 
     override fun onCreate() {
         super.onCreate()
-        FlutterFirebaseMessagingService.setPluginRegistrant(this);
-    }
-
-    override fun registerWith(registry: PluginRegistry?) {
-        io.flutter.plugins.firebasemessaging.FirebaseMessagingPlugin.registerWith(registry?.registrarFor("io.flutter.plugins.firebasemessaging.FirebaseMessagingPlugin"));
     }
 }


### PR DESCRIPTION
According to Flutter firebase docs we don't need to register the plugin manually anymore. 

https://firebase.flutter.dev/docs/messaging/overview/